### PR TITLE
feat: Basic認証情報をSOPS(age)で暗号化して管理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# macOS
+.DS_Store
+
+# SOPS / age — 秘密鍵と復号済みファイルは絶対にコミットしない。
+# （暗号化済みの *.sops.yaml は安全なのでコミット対象。ここでは除外しない）
+*.agekey
+age-key.txt
+keys.txt
+*.dec
+*.dec.*
+*.decrypted
+*.decrypted.*
+secrets.plain.*

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,3 +2,5 @@
 node = "22"
 pnpm = "9"
 terraform = "1.15"
+sops = "latest"
+age = "latest"

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,7 @@
+# SOPS 暗号化ルール。対象ファイルを age 公開鍵で暗号化する。
+# 秘密鍵は ~/.config/sops/age/keys.txt（リポジトリ外）。公開鍵はここにコミットしてよい。
+creation_rules:
+  - path_regex: infra/secrets\.sops\.ya?ml$
+    # 値のみ暗号化（キー名は平文のまま diff で追える）
+    encrypted_regex: "^(basic_auth_username|basic_auth_password)$"
+    age: "age1qyr4xznv0exnxacqlyy6x4wz8c7yhdw5h5gj7rmqf0wms55agfrszhgveq"

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,6 +1,21 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/carlpett/sops" {
+  version     = "1.4.1"
+  constraints = "~> 1.1"
+  hashes = [
+    "h1:nTX8t1aP800EVoUFK9p7/IfSihRN3CAgTiawINe2CLY=",
+    "zh:4df8dea170a4cd926ca6ef0b9fa6fd1d8c1fa9bc9e78333d544a74c24e269cf9",
+    "zh:5cf661333ec5d5cce3b7c0fc399052cf8f8c50f6cb0a50f5aec2f91d83685e1e",
+    "zh:680616383404bc836a2d740a0dfae4691c18c8616f346e8fa795a1d790a2d888",
+    "zh:8ef127e590bd676718bc82afc0f1cad8d0a93d82e935ec21b22d6ae2fc2bff9f",
+    "zh:d030531c7b61922d4f4150c45a87c48ed5c6743348dbbfe70d34191cd13f2649",
+    "zh:d8c138c2c0d7c7d4e72a4ab667772e8f96ec17e13ffe0c6fbe21457e82c140f0",
+    "zh:fd3903e0f2040b67550bbce3b58e4e615a738993bc787f71adbc41afe38df518",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.60"

--- a/infra/README.md
+++ b/infra/README.md
@@ -7,6 +7,8 @@
 infra/
 ├─ amplify.tf           # Amplifyアプリ + 公開ブランチ + Basic認証
 ├─ iam_github_oidc.tf   # GitHub Actions用 OIDCプロバイダー + デプロイロール（最小権限）
+├─ secrets.tf           # SOPS で暗号化した Basic認証情報を復号して参照
+├─ secrets.sops.yaml    # Basic認証情報（age で暗号化済み・コミットOK）
 ├─ variables.tf / outputs.tf / providers.tf / versions.tf
 └─ terraform.tfvars.example
 ```
@@ -16,22 +18,42 @@ infra/
 - **手動デプロイ方式**: Amplify にリポジトリを接続せず（`aws_amplify_app` に `repository` を指定しない）、
   ビルド〜デプロイはすべて GitHub Actions が担う。CI/CD を GitHub Actions に集約するため。
 - **セキュア**:
-  - 閲覧は Amplify ブランチの **Basic認証** で保護（資格情報は Terraform 変数。コードにハードコードしない）。
+  - 閲覧は Amplify ブランチの **Basic認証** で保護。資格情報は **SOPS + age で暗号化**して Git に置く（平文はコミットしない）。
   - GitHub Actions → AWS は **OIDC の一時クレデンシャル**。長期アクセスキーを Secrets に置かない。
   - デプロイロールは対象 Amplify アプリのみに権限を限定。
+
+## 0. Basic認証情報（SOPS）の準備
+
+Basic認証のユーザー名/パスワードは `infra/secrets.sops.yaml` に **age で暗号化**して格納する。
+暗号化ルールはリポジトリ直下の `.sops.yaml`（age 公開鍵を記載・コミット済み）。
+
+```bash
+# 必要ツール（.mise.toml で管理）
+mise install                       # sops / age を導入
+
+# 鍵（初回のみ・既に作成済みなら不要）。秘密鍵は下記パスに保存しコミットしない。
+#   macOS:  ~/Library/Application Support/sops/age/keys.txt
+#   Linux:  ~/.config/sops/age/keys.txt （または環境変数 SOPS_AGE_KEY_FILE で指定）
+# 新しい鍵を作る場合は公開鍵を .sops.yaml の age: に差し替えて再暗号化する。
+
+# 値の編集（自動で復号→エディタ→保存時に再暗号化）
+sops infra/secrets.sops.yaml
+#   basic_auth_username: <任意のユーザー名>
+#   basic_auth_password: <強いパスワード>
+```
+
+> ⚠️ age 秘密鍵を紛失すると復号できなくなる。1Password 等にバックアップしておく。
+> 別マシン/CI から apply する場合は、その秘密鍵を環境変数 `SOPS_AGE_KEY`（中身）または
+> `SOPS_AGE_KEY_FILE`（パス）で渡す。
 
 ## 1. インフラを作成（ローカルから一度だけ）
 
 ```bash
 cd infra
-cp terraform.tfvars.example terraform.tfvars   # 値を埋める（Basic認証のユーザー名/パス等）
-
-# Basic認証情報は環境変数で渡してもよい（tfvarsに書かない場合）
-# export TF_VAR_basic_auth_username='your-name'
-# export TF_VAR_basic_auth_password='strong-password'
+cp terraform.tfvars.example terraform.tfvars   # Basic認証以外の値（任意で編集）
 
 terraform init
-terraform plan
+terraform plan      # secrets.sops.yaml が自動復号され Amplify に渡る
 terraform apply
 ```
 
@@ -74,7 +96,10 @@ Settings → Secrets and variables → Actions に登録する。
 
 ## 認証情報を変更したいとき
 
-`terraform.tfvars`（または環境変数）の `basic_auth_*` を変えて `terraform apply`。
+```bash
+sops infra/secrets.sops.yaml   # 復号→値を編集→保存で再暗号化
+cd infra && terraform apply    # 新しい資格情報を Amplify に反映
+```
 
 ## 状態管理について
 

--- a/infra/amplify.tf
+++ b/infra/amplify.tf
@@ -20,7 +20,7 @@ resource "aws_amplify_branch" "main" {
   stage       = "PRODUCTION"
 
   enable_basic_auth      = true
-  basic_auth_credentials = base64encode("${var.basic_auth_username}:${var.basic_auth_password}")
+  basic_auth_credentials = base64encode("${local.basic_auth_username}:${local.basic_auth_password}")
 
   # 手動デプロイ運用のため自動ビルドは無効
   enable_auto_build = false

--- a/infra/secrets.sops.yaml
+++ b/infra/secrets.sops.yaml
@@ -1,0 +1,17 @@
+basic_auth_username: ENC[AES256_GCM,data:eroWFhMRMliH,iv:CVzmlfdMcRWSnVp3/U9qyzBYlMAuR8bvMPHAaTEqsZM=,tag:Oz1D6enw+RH2h+rr9srOnw==,type:str]
+basic_auth_password: ENC[AES256_GCM,data:6xQ4mBeuOQah1EJoXm+cg866xwE=,iv:LK+LnEfVW960qbtPq5ZYamkTXs7DS8BrftIXDBSnc/E=,tag:FxZ5lgq8dibkXQ9XQ8vdOA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWejBHV1BJSUh5eXA0SVRM
+            SkhjOHk3Y2Q2YnBWM1JOd0dtRi85S2hOK2hFCjFHZ0R1Q0p5Q3BEa0lWNmI2MUdL
+            RzAvbnR6aEVDaTB0cUxBS3VXMjNXN00KLS0tIG1LcFZSYVQ1cWE3TkMxY3VMSFBz
+            V0QzQXFNaWljUU9TWEF6b1hlRWpLOHcKV949DEegiXM2spq3/l2GuQArfnFHM4n4
+            3ZJXECNHwvsZ49Sbtp+AAVbfl9seFWFIkm0xK5sFvD7aaDYjkXKSjQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1qyr4xznv0exnxacqlyy6x4wz8c7yhdw5h5gj7rmqf0wms55agfrszhgveq
+    encrypted_regex: ^(basic_auth_username|basic_auth_password)$
+    lastmodified: "2026-06-13T12:19:49Z"
+    mac: ENC[AES256_GCM,data:3FotBqGmG7qy6Dh4LkYWf/UozvjvDu4PDdov4+iiBCibpRMXKj/I45zUPkBW7kq2AIsUEs9xjnNC9oJk8oWmOJJbe2KSizCWUKWu6bdMX8TMnK4l7Mw2AP0dHiGn1IFDk3RFmxoEthmR95pqeQ2EvMPvH3WT3PO95jJ0rWY5cmY=,iv:T8sEREWXW4G453na/Fc0YmO3aLr/u9HWKk1FhP1INos=,tag:GyL2TAEEMKnv9ArUHtQwcg==,type:str]
+    version: 3.13.1

--- a/infra/secrets.tf
+++ b/infra/secrets.tf
@@ -1,0 +1,12 @@
+# SOPS で暗号化した secrets.sops.yaml を復号して参照する。
+# 復号には age 秘密鍵が必要:
+#   - ローカル: ~/.config/sops/age/keys.txt を自動検出
+#   - 別マシン/CI: 環境変数 SOPS_AGE_KEY または SOPS_AGE_KEY_FILE で渡す
+data "sops_file" "secrets" {
+  source_file = "${path.module}/secrets.sops.yaml"
+}
+
+locals {
+  basic_auth_username = data.sops_file.secrets.data["basic_auth_username"]
+  basic_auth_password = data.sops_file.secrets.data["basic_auth_password"]
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,15 +1,14 @@
 # このファイルを terraform.tfvars にコピーして値を埋める。
 # terraform.tfvars は .gitignore 済み（機密のためコミットしない）。
-# あるいは環境変数 TF_VAR_basic_auth_username / TF_VAR_basic_auth_password で渡す。
+#
+# Basic認証の資格情報はここではなく SOPS で管理する:
+#   sops infra/secrets.sops.yaml   # 復号→編集→自動再暗号化
+# 値は secrets.tf 経由で apply 時に復号され Amplify に渡る。
 
 aws_region        = "ap-northeast-1"
 app_name          = "bunko"
 branch_name       = "main"
 github_repository = "kawafuchieirin/aws-exam"
-
-# Basic認証の資格情報（閲覧時に要求されるユーザー名/パスワード）
-basic_auth_username = "change-me"
-basic_auth_password = "use-a-strong-password"
 
 # OIDCプロバイダーがアカウントに未作成なら true、既存なら false
 create_oidc_provider = true

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -22,17 +22,8 @@ variable "github_repository" {
   default     = "kawafuchieirin/aws-exam"
 }
 
-variable "basic_auth_username" {
-  description = "Basic認証のユーザー名。tfvars か環境変数 TF_VAR_basic_auth_username で渡す（コミット禁止）"
-  type        = string
-  sensitive   = true
-}
-
-variable "basic_auth_password" {
-  description = "Basic認証のパスワード。tfvars か環境変数 TF_VAR_basic_auth_password で渡す（コミット禁止）"
-  type        = string
-  sensitive   = true
-}
+# Basic認証の資格情報は変数ではなく SOPS（infra/secrets.sops.yaml）で管理する。
+# secrets.tf の data.sops_file 経由で local.basic_auth_username / password として参照。
 
 variable "create_oidc_provider" {
   description = "GitHub Actions 用の OIDC プロバイダーを新規作成するか。アカウントに既存ならfalseにして既存を参照"

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -6,6 +6,11 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.60"
     }
+    # SOPS で暗号化した secrets.sops.yaml を apply 時に復号する。
+    sops = {
+      source  = "carlpett/sops"
+      version = "~> 1.1"
+    }
   }
 
   # 状態ファイルはデフォルトでローカル(terraform.tfstate)。


### PR DESCRIPTION
## 概要

Amplify の Basic認証（ユーザー名/パスワード）を Terraform 変数から **SOPS(age) で暗号化したファイル**へ移行します。平文をリポジトリに置かず、`terraform apply` 時に自動復号して Amplify に渡します。

## なぜ
- 従来は `TF_VAR_basic_auth_*`（環境変数 / 平文tfvars）で渡しており、運用ごとに手元で平文を扱う必要があった。
- 秘密情報を暗号化したままGit管理し、apply時のみ復号する形にして取り回しと安全性を改善する。

## 仕組み
```
sops infra/secrets.sops.yaml      ← age公開鍵で暗号化してコミット
        │ terraform apply
        ▼
data "sops_file"（carlpett/sops）が age秘密鍵で復号 → local.basic_auth_* → amplify.tf
```
- 暗号鍵は **age**。公開鍵は `.sops.yaml` にコミット、**秘密鍵はリポジトリ外**（macOS: `~/Library/Application Support/sops/age/keys.txt`）。
- 別マシン/CIでは `SOPS_AGE_KEY` / `SOPS_AGE_KEY_FILE` で鍵を渡せる。

## 変更点
- `.sops.yaml`（新規）: 暗号化ルール（値のみ暗号化、age公開鍵）
- `infra/secrets.sops.yaml`（新規・暗号化済み）: Basic認証情報の格納先
- `infra/secrets.tf`（新規）: `data "sops_file"` + `locals`
- `infra/versions.tf`: `carlpett/sops` provider 追加
- `infra/amplify.tf`: `var.basic_auth_*` → `local.basic_auth_*`
- `infra/variables.tf`: 旧 `basic_auth_*` 変数を削除
- `.mise.toml`: `sops` / `age` 追加
- `.gitignore`（新規）: age秘密鍵・復号済みファイルの誤コミット防止
- `infra/README.md` / `terraform.tfvars.example`: SOPS運用手順へ更新

## 動作確認
- `terraform init`（sops provider取得）/ `terraform validate` 成功
- `sops -d` で環境変数なし復号成功（macOS既定パス）
- 秘密鍵はGit未追跡、`secrets.sops.yaml` の値は `ENC[...]` で暗号化済み

## 運用メモ
- 認証情報の変更: `sops infra/secrets.sops.yaml` で編集 → `terraform apply`
- ⚠️ age秘密鍵を紛失すると復号不能。バックアップ必須。

🤖 Generated with [Claude Code](https://claude.com/claude-code)