### PR TITLE
feat: ANS-C01 問題集トラッカーを要点文庫に追加

### DIFF
--- a/bunko/astro.config.mjs
+++ b/bunko/astro.config.mjs
@@ -19,7 +19,13 @@ export default defineConfig({
 			},
 			pagefind: true, // 全文検索（静的・クライアントサイドで完結）
 			sidebar: [
-				{ label: 'ANS-C01 ネットワーク要点', items: [{ autogenerate: { directory: 'ans' } }] },
+				{
+					label: 'ANS-C01 ネットワーク要点',
+					items: [
+						{ label: '📝 問題集トラッカー', link: '/ans/quiz' },
+						{ autogenerate: { directory: 'ans' } },
+					],
+				},
 				{ label: 'AIP-C01 生成AI 参考書', items: [{ autogenerate: { directory: 'aip' } }] },
 			],
 		}),

--- a/bunko/src/pages/ans/quiz.astro
+++ b/bunko/src/pages/ans/quiz.astro
@@ -1,0 +1,203 @@
+---
+// ANS-C01 問題集トラッカー
+// 外部の問題集（①250問 / 模擬220問）について「どの問題を解かなくていいか」を
+// 番号単位で記録する。問題文そのものは扱わず、状態だけをブラウザ(localStorage)に保存する。
+// 静的サイトのためサーバ不要・端末ごとに記録が残る。
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+---
+
+<StarlightPage
+	frontmatter={{
+		title: 'ANS-C01 問題集トラッカー',
+		description: '外部の問題集について、理解済み（みし）で解かなくてよい問題を番号で記録する。記録はブラウザに保存。',
+		tableOfContents: false,
+	}}
+>
+	<p>
+		手元の問題集の「番号」をタップして状態を切り替えます。問題文は扱いません。
+		記録は<strong>このブラウザ（端末）</strong>に保存され、次回も残ります。
+	</p>
+
+	<div class="legend" aria-hidden="true">
+		<span class="chip s-none">未着手</span>
+		<span class="chip s-mastered">理解済み（みし）</span>
+		<span class="chip s-review">要復習</span>
+	</div>
+	<p class="muted">
+		タップで <em>未着手 → 理解済み → 要復習 → 未着手</em> と切り替わります。
+		<strong>理解済み（みし）</strong>は一覧から隠れ、解く対象から外れます。下のトグルでいつでも再表示できます。
+	</p>
+
+	<label class="toggle">
+		<input type="checkbox" id="show-mastered" />
+		理解済み（みし）も表示する
+	</label>
+
+	<div id="tracker"></div>
+
+	<style>
+		.legend { display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 0.5rem 0; }
+		.chip {
+			display: inline-flex; align-items: center; gap: 0.3rem;
+			padding: 0.15rem 0.6rem; border-radius: 999px; font-size: 0.8rem;
+			border: 1px solid var(--sl-color-gray-5);
+		}
+		.chip::before { content: ''; width: 0.7rem; height: 0.7rem; border-radius: 3px; display: inline-block; }
+		.s-none::before { background: var(--sl-color-gray-4); }
+		.s-mastered::before { background: #2e7d32; }
+		.s-review::before { background: #ed6c02; }
+		.muted { color: var(--sl-color-gray-3); font-size: 0.9rem; }
+		.toggle { display: inline-flex; align-items: center; gap: 0.4rem; margin: 0.5rem 0 1.5rem; cursor: pointer; }
+
+		.deck { margin: 0 0 2.5rem; }
+		.deck h2 { margin-bottom: 0.25rem; }
+		.summary { display: flex; flex-wrap: wrap; gap: 0.5rem 1.25rem; margin: 0.5rem 0 0.75rem; font-size: 0.95rem; }
+		.summary b { font-variant-numeric: tabular-nums; }
+		.summary .remain b { color: var(--sl-color-text-accent); }
+		.bar { height: 8px; border-radius: 999px; background: var(--sl-color-gray-6); overflow: hidden; margin: 0.25rem 0 0.75rem; }
+		.bar > span { display: block; height: 100%; background: #2e7d32; width: 0; transition: width 0.2s; }
+
+		.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(2.6rem, 1fr)); gap: 0.35rem; }
+		.cell {
+			aspect-ratio: 1 / 1; min-height: 2.6rem; border: 1px solid var(--sl-color-gray-5);
+			border-radius: 6px; background: var(--sl-color-black); color: var(--sl-color-white);
+			font-size: 0.85rem; font-variant-numeric: tabular-nums; cursor: pointer;
+			display: flex; align-items: center; justify-content: center; padding: 0; line-height: 1;
+		}
+		.cell:hover { border-color: var(--sl-color-text-accent); }
+		.cell.mastered { background: #2e7d32; color: #fff; border-color: #2e7d32; }
+		.cell.review { background: #ed6c02; color: #fff; border-color: #ed6c02; }
+		.cell.mastered.dimmed { opacity: 0.45; }
+
+		.deck-actions { margin-top: 0.75rem; }
+		.deck-actions button {
+			font-size: 0.85rem; padding: 0.3rem 0.8rem; border-radius: 6px;
+			border: 1px solid var(--sl-color-gray-5); background: transparent; color: inherit; cursor: pointer;
+		}
+		.deck-actions button:hover { border-color: var(--sl-color-text-accent); }
+	</style>
+
+	<script>
+		// ---- 設定（問題集と問題数）。名称・問題数はここを編集すれば変更可 ----
+		const DECKS = [
+			{ id: 'set1', label: '問題集①', count: 250 },
+			{ id: 'mock', label: '模擬試験', count: 220 },
+		];
+		const STORAGE_KEY = 'ans-quiz-tracker-v1';
+		// 状態の遷移順。空（未着手）は保存しない。
+		const CYCLE = [undefined, 'mastered', 'review'];
+
+		/** @type {{[deck:string]: {[n:string]: string}}} */
+		let state = {};
+		try {
+			state = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}') || {};
+		} catch {
+			state = {};
+		}
+
+		const save = () => localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+		const deckState = (id) => (state[id] ||= {});
+
+		const root = document.getElementById('tracker');
+		const showMasteredEl = /** @type {HTMLInputElement} */ (document.getElementById('show-mastered'));
+
+		function nextStatus(cur) {
+			const i = CYCLE.indexOf(cur);
+			return CYCLE[(i + 1) % CYCLE.length];
+		}
+
+		function applyCell(btn, status, showMastered) {
+			btn.classList.toggle('mastered', status === 'mastered');
+			btn.classList.toggle('review', status === 'review');
+			btn.classList.toggle('dimmed', status === 'mastered' && showMastered);
+			// 理解済みは隠す（トグルONなら薄く表示）
+			btn.style.display = status === 'mastered' && !showMastered ? 'none' : '';
+			const label =
+				status === 'mastered' ? '理解済み' : status === 'review' ? '要復習' : '未着手';
+			btn.setAttribute('aria-label', `${btn.dataset.n}番: ${label}`);
+			btn.title = label;
+		}
+
+		function updateSummary(deck) {
+			const ds = deckState(deck.id);
+			let mastered = 0;
+			let review = 0;
+			for (let n = 1; n <= deck.count; n++) {
+				const s = ds[n];
+				if (s === 'mastered') mastered++;
+				else if (s === 'review') review++;
+			}
+			const remain = deck.count - mastered;
+			const el = document.getElementById(`sum-${deck.id}`);
+			if (el) {
+				el.querySelector('.j-total').textContent = String(deck.count);
+				el.querySelector('.j-mastered').textContent = String(mastered);
+				el.querySelector('.j-review').textContent = String(review);
+				el.querySelector('.j-remain').textContent = String(remain);
+			}
+			const bar = document.getElementById(`bar-${deck.id}`);
+			if (bar) bar.style.width = `${(mastered / deck.count) * 100}%`;
+		}
+
+		function render() {
+			const showMastered = showMasteredEl.checked;
+			root.innerHTML = '';
+			for (const deck of DECKS) {
+				const ds = deckState(deck.id);
+				const section = document.createElement('section');
+				section.className = 'deck';
+				section.innerHTML = `
+					<h2>${deck.label}（${deck.count}問）</h2>
+					<div class="summary" id="sum-${deck.id}">
+						<span>総数 <b class="j-total">0</b></span>
+						<span>理解済み <b class="j-mastered">0</b></span>
+						<span>要復習 <b class="j-review">0</b></span>
+						<span class="remain">残り <b class="j-remain">0</b></span>
+					</div>
+					<div class="bar"><span id="bar-${deck.id}"></span></div>
+				`;
+				const grid = document.createElement('div');
+				grid.className = 'grid';
+				for (let n = 1; n <= deck.count; n++) {
+					const btn = document.createElement('button');
+					btn.className = 'cell';
+					btn.type = 'button';
+					btn.dataset.n = String(n);
+					btn.textContent = String(n);
+					applyCell(btn, ds[n], showMastered);
+					btn.addEventListener('click', () => {
+						const cur = ds[n];
+						const next = nextStatus(cur);
+						if (next === undefined) delete ds[n];
+						else ds[n] = next;
+						save();
+						applyCell(btn, ds[n], showMasteredEl.checked);
+						updateSummary(deck);
+					});
+					grid.appendChild(btn);
+				}
+				section.appendChild(grid);
+
+				const actions = document.createElement('div');
+				actions.className = 'deck-actions';
+				const reset = document.createElement('button');
+				reset.type = 'button';
+				reset.textContent = 'この問題集の記録をリセット';
+				reset.addEventListener('click', () => {
+					if (!confirm(`${deck.label}の記録をすべて消去します。よろしいですか？`)) return;
+					state[deck.id] = {};
+					save();
+					render();
+				});
+				actions.appendChild(reset);
+				section.appendChild(actions);
+
+				root.appendChild(section);
+				updateSummary(deck);
+			}
+		}
+
+		showMasteredEl.addEventListener('change', render);
+		render();
+	</script>
+</StarlightPage>


### PR DESCRIPTION
## 概要

外部の問題集について「**理解済み（みし）＝解かなくてよい問題**」を番号単位で記録できるトラッカーを要点文庫に追加しました。問題文そのものは扱わず、状態だけを管理します。

対応した2つの問題集：
- **問題集①**（250問）
- **模擬試験**（220問）

## 機能

- ページ `/ans/quiz`（Starlight に統合、ANSサイドバーに導線を追加）
- 番号タップで状態が循環：**未着手 → 理解済み（みし） → 要復習 → 未着手**
- **理解済み（みし）は一覧から隠れ、解く対象から外れる**。「理解済みも表示」トグルでいつでも再表示
- **記録はブラウザ（localStorage）に保存** … 静的サイトのためサーバ不要・同じ端末/ブラウザなら次回も残る
- 問題集ごとに **総数 / 理解済み / 要復習 / 残り** のサマリ＋進捗バー、リセットボタン

## 設計判断

- サイトは静的ホスティング（Amplify + Basic認証）のため、記録保持は **localStorage（端末ごと）** を採用
- 問題の中身は不要（「どれを解かなくていいか分かればよい」）のため、番号トラッカーに特化
- 問題数・名称は `quiz.astro` の `DECKS` 定数で変更可能

## テスト計画

- [x] `pnpm build` でビルド成功・`/ans/quiz` 生成を確認
- [x] 出力に問題集定義（250/220）とトラッカーロジックが含まれることを確認
- [ ] 実機（スマホ/PC）でタップ操作・localStorage 永続を確認

## 注意（既知の制約）

- localStorage のため**端末/ブラウザごとに記録は独立**（端末間同期はバックエンドが必要なため対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)