### PR TITLE
chore(infra): Terraform plan成果物を除外しSOPS手順を整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,12 @@ keys.txt
 *.decrypted
 *.decrypted.*
 secrets.plain.*
+
+# Terraform — plan成果物(平文の機密を含みうる)・state・ローカル設定はコミットしない
+tfplan
+*.tfplan
+*.tfstate
+*.tfstate.*
+.terraform/
+terraform.tfvars
+# .terraform.lock.hcl はプロバイダ版固定のためコミットする（除外しない）

--- a/infra/README.md
+++ b/infra/README.md
@@ -40,6 +40,8 @@ mise install                       # sops / age を導入
 sops infra/secrets.sops.yaml
 #   basic_auth_username: <任意のユーザー名>
 #   basic_auth_password: <強いパスワード>
+# エディタを明示したい場合は EDITOR を前置する:
+#   EDITOR=vim sops infra/secrets.sops.yaml
 ```
 
 > ⚠️ age 秘密鍵を紛失すると復号できなくなる。1Password 等にバックアップしておく。


### PR DESCRIPTION
## 概要

セッション中に残っていた `infra/` の未整理な変更を整理しました。

## 変更内容

### `.gitignore`
Terraform の生成物・ローカル設定を除外（**plan 成果物は平文の機密を含みうるためコミットしない**）：

- `tfplan` / `*.tfplan`（← 未追跡で残っていた `infra/tfplan` を除外）
- `*.tfstate` / `*.tfstate.*` / `.terraform/`
- `terraform.tfvars`（実値。`.example` はコミット対象のまま）
- `.terraform.lock.hcl` は**プロバイダ版固定のため除外せずコミット対象**である旨を明記

### `infra/README.md`
- 末尾に改行なしで雑に追記されていた `EDITOR=vim sops infra/secrets.sops.yaml` を除去
- 同コマンドの意図（エディタ指定）を **SOPS 編集手順のTip** として適切な位置に統合

## 補足

- `infra/tfplan` 自体はコミットせず、`.gitignore` で追跡対象外にしました（`git check-ignore` で確認済み）。手元のファイルは残りますが Git には乗りません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)