### PR TITLE
feat: 問題集トラッカーに採点フロー高速化と振り返りノートを追加

### DIFF
--- a/bunko/src/pages/ans/quiz.astro
+++ b/bunko/src/pages/ans/quiz.astro
@@ -59,10 +59,18 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 
 	<div id="tracker"></div>
 
+	<section class="notes" id="notes-section">
+		<h2>振り返りノート（<span id="notes-count">0</span>件）</h2>
+		<p class="muted" id="notes-empty">問題にメモを書くと、ここに弱点ノートとして集約されます。各項目をタップすると編集できます。</p>
+		<ul class="notes-list" id="notes-list"></ul>
+	</section>
+
 	<dialog id="detail" class="detail">
 		<div class="detail-card">
 			<header class="detail-head">
+				<button type="button" class="d-nav" id="d-prev" aria-label="前の問題">◀</button>
 				<h3 id="d-title">問題</h3>
+				<button type="button" class="d-nav" id="d-next" aria-label="次の問題">▶</button>
 				<button type="button" class="d-x" id="d-close" aria-label="閉じる">×</button>
 			</header>
 
@@ -90,6 +98,8 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 				<div class="d-label">振り返りメモ</div>
 				<textarea id="d-comment" rows="3" placeholder="なぜ間違えた？ どこがポイント？ 次に気をつけること など"></textarea>
 			</div>
+
+			<p class="d-hint">キー: <b>1</b>=× <b>2</b>=○ <b>3</b>=◎ ／ <b>←</b> <b>→</b> で前後の問題へ</p>
 
 			<footer class="detail-foot">
 				<button type="button" class="d-delete" id="d-delete">この問題の記録を消す</button>
@@ -143,6 +153,24 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 		.dash-deck-head { display: flex; justify-content: space-between; font-size: 0.9rem; margin-bottom: 0.25rem; }
 		.dash-deck-head span:last-child { font-variant-numeric: tabular-nums; color: var(--sl-color-gray-3); }
 
+		/* 振り返りノート */
+		.notes { margin: 0.5rem 0 2.5rem; }
+		.notes h2 { font-size: 1.1rem; border: none; margin-bottom: 0.5rem; }
+		.notes-list { list-style: none; padding: 0; margin: 0; display: grid; gap: 0.5rem; }
+		.note-item {
+			display: flex; flex-direction: column; gap: 0.25rem; width: 100%; text-align: left;
+			padding: 0.55rem 0.75rem; border: 1px solid var(--sl-color-gray-5); border-radius: 8px;
+			background: transparent; color: inherit; cursor: pointer; font: inherit;
+		}
+		.note-item:hover { border-color: var(--sl-color-text-accent); }
+		.note-head { display: flex; align-items: center; flex-wrap: wrap; gap: 0.4rem; font-size: 0.82rem; color: var(--sl-color-gray-2); }
+		.note-mark { font-weight: 700; font-size: 0.95rem; }
+		.note-mark.m-x { color: #c62828; }
+		.note-mark.m-o { color: #f9a825; }
+		.note-mark.m-oo { color: #2e7d32; }
+		.note-narrowed { font-size: 0.7rem; padding: 0 0.3rem; border-radius: 4px; border: 1px solid var(--sl-color-gray-5); }
+		.note-comment { white-space: pre-wrap; font-size: 0.92rem; line-height: 1.4; }
+
 		.deck { margin: 0 0 2.5rem; }
 		.deck h2 { margin-bottom: 0.25rem; }
 		.summary { display: flex; flex-wrap: wrap; gap: 0.5rem 1.25rem; margin: 0.5rem 0 0.75rem; font-size: 0.95rem; }
@@ -191,8 +219,14 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 		}
 		.detail::backdrop { background: rgba(0, 0, 0, 0.5); }
 		.detail-card { padding: 1rem 1.1rem 1.1rem; }
-		.detail-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.75rem; }
-		.detail-head h3 { margin: 0; font-size: 1.05rem; border: none; }
+		.detail-head { display: flex; align-items: center; gap: 0.35rem; margin-bottom: 0.75rem; }
+		.detail-head h3 { margin: 0; flex: 1; text-align: center; font-size: 1.05rem; border: none; }
+		.d-nav {
+			border: 1px solid var(--sl-color-gray-5); background: transparent; color: inherit;
+			width: 1.9rem; height: 1.9rem; border-radius: 6px; cursor: pointer; font-size: 0.8rem; flex: none;
+		}
+		.d-nav:hover:not(:disabled) { border-color: var(--sl-color-text-accent); }
+		.d-nav:disabled { opacity: 0.35; cursor: default; }
 		.d-x {
 			border: none; background: transparent; color: var(--sl-color-gray-2);
 			font-size: 1.4rem; line-height: 1; cursor: pointer; padding: 0 0.25rem;
@@ -225,6 +259,8 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 			padding: 0.5rem 0.6rem; border-radius: 8px;
 			border: 1px solid var(--sl-color-gray-5); background: var(--sl-color-gray-7); color: inherit;
 		}
+		.d-hint { margin: 0 0 0.6rem; font-size: 0.72rem; color: var(--sl-color-gray-3); text-align: center; }
+		.d-hint b { font-variant-numeric: tabular-nums; color: var(--sl-color-gray-2); }
 		.detail-foot { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; margin-top: 0.25rem; }
 		.d-delete {
 			font-size: 0.8rem; padding: 0.35rem 0.6rem; border-radius: 6px; cursor: pointer;
@@ -293,6 +329,8 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 
 		const root = document.getElementById('tracker');
 		const showMasteredEl = /** @type {HTMLInputElement} */ (document.getElementById('show-mastered'));
+		/** 番号→セル要素の対応表。前後移動やノートからのジャンプに使う。@type {{[deck:string]: {[n:number]: HTMLButtonElement}}} */
+		let cellMap = {};
 
 		const MARK_SYMBOL = { x: '×', o: '○', oo: '◎' };
 
@@ -387,6 +425,8 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 		const dMarks = document.getElementById('d-marks');
 		const dNarrowed = document.getElementById('d-narrowed');
 		const dComment = /** @type {HTMLTextAreaElement} */ (document.getElementById('d-comment'));
+		const dPrev = /** @type {HTMLButtonElement} */ (document.getElementById('d-prev'));
+		const dNext = /** @type {HTMLButtonElement} */ (document.getElementById('d-next'));
 		/** 編集中の対象。{deck, n, btn} */
 		let editing = null;
 
@@ -398,7 +438,10 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 			dNarrowed.querySelectorAll('button').forEach((b) =>
 				b.classList.toggle('active', Number(b.dataset.narrowed) === (rec.narrowed || 0) && rec.narrowed > 0)
 			);
-			dComment.value = rec.comment || '';
+			// メモ入力中はカーソルが飛ばないよう値を上書きしない
+			if (document.activeElement !== dComment) dComment.value = rec.comment || '';
+			dPrev.disabled = editing.n <= 1;
+			dNext.disabled = editing.n >= editing.deck.count;
 		}
 
 		function commitEdit(mutate) {
@@ -408,6 +451,7 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 			applyCell(editing.btn, getRec(editing.deck.id, editing.n), showMasteredEl.checked);
 			updateSummary(editing.deck);
 			updateDashboard();
+			renderNotes();
 			refreshPanel();
 		}
 
@@ -415,7 +459,15 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 			editing = { deck, n, btn };
 			dTitle.textContent = `${deck.label} ${n}番`;
 			refreshPanel();
-			dialog.showModal();
+			if (!dialog.open) dialog.showModal();
+		}
+
+		/** 詳細パネルを開いたまま前後の問題へ移動する。 */
+		function navigate(delta) {
+			if (!editing) return;
+			const newN = editing.n + delta;
+			if (newN < 1 || newN > editing.deck.count) return;
+			openDetail(editing.deck, newN, cellMap[editing.deck.id][newN]);
 		}
 
 		dMarks.addEventListener('click', (e) => {
@@ -444,21 +496,80 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 			applyCell(editing.btn, undefined, showMasteredEl.checked);
 			updateSummary(editing.deck);
 			updateDashboard();
+			renderNotes();
 			dialog.close();
 		});
 
 		document.getElementById('d-done').addEventListener('click', () => dialog.close());
 		document.getElementById('d-close').addEventListener('click', () => dialog.close());
+		dPrev.addEventListener('click', () => navigate(-1));
+		dNext.addEventListener('click', () => navigate(1));
 		// 背景クリックで閉じる
 		dialog.addEventListener('click', (e) => {
 			if (e.target === dialog) dialog.close();
 		});
 
+		// キーボードでの採点（メモ入力中は無効）。1/2/3=×○◎、←→=前後の問題。
+		const KEY_MARK = { '1': 'x', '2': 'o', '3': 'oo' };
+		dialog.addEventListener('keydown', (e) => {
+			if (!editing || document.activeElement === dComment) return;
+			if (e.key === 'ArrowLeft') { e.preventDefault(); navigate(-1); }
+			else if (e.key === 'ArrowRight') { e.preventDefault(); navigate(1); }
+			else if (KEY_MARK[e.key]) {
+				e.preventDefault();
+				const mark = KEY_MARK[e.key];
+				commitEdit((rec) => { rec.mark = rec.mark === mark ? undefined : mark; });
+			}
+		});
+
+		// ---- 振り返りノート（メモのある問題を集約） ----
+		const notesList = document.getElementById('notes-list');
+		const notesCount = document.getElementById('notes-count');
+		const notesEmpty = document.getElementById('notes-empty');
+
+		function renderNotes() {
+			const items = [];
+			for (const deck of DECKS) {
+				const ds = deckState(deck.id);
+				for (let n = 1; n <= deck.count; n++) {
+					const rec = ds[n];
+					if (rec && rec.comment) items.push({ deck, n, rec });
+				}
+			}
+			notesCount.textContent = String(items.length);
+			notesEmpty.hidden = items.length > 0;
+			notesList.innerHTML = items
+				.map(({ deck, n, rec }) => {
+					const sym = MARK_SYMBOL[rec.mark] || '―';
+					const mClass = rec.mark ? `m-${rec.mark}` : '';
+					const narrowed = rec.narrowed ? `<span class="note-narrowed">${rec.narrowed}択</span>` : '';
+					return `<li><button type="button" class="note-item" data-deck="${deck.id}" data-n="${n}">
+						<span class="note-head"><span class="note-mark ${mClass}">${sym}</span>${deck.label} ${n}番${narrowed}</span>
+						<span class="note-comment"></span>
+					</button></li>`;
+				})
+				.join('');
+			// コメントはユーザー入力のため textContent で安全に挿入
+			notesList.querySelectorAll('.note-item').forEach((b, i) => {
+				b.querySelector('.note-comment').textContent = items[i].rec.comment;
+			});
+		}
+
+		notesList.addEventListener('click', (e) => {
+			const b = e.target.closest('.note-item');
+			if (!b) return;
+			const deck = DECKS.find((d) => d.id === b.dataset.deck);
+			const n = Number(b.dataset.n);
+			if (deck) openDetail(deck, n, cellMap[deck.id][n]);
+		});
+
 		function render() {
 			const showMastered = showMasteredEl.checked;
 			root.innerHTML = '';
+			cellMap = {};
 			for (const deck of DECKS) {
 				const ds = deckState(deck.id);
+				cellMap[deck.id] = {};
 				const section = document.createElement('section');
 				section.className = 'deck';
 				section.innerHTML = `
@@ -486,6 +597,7 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 						`<span class="c-comment" hidden aria-hidden="true"></span>`;
 					applyCell(btn, ds[n], showMastered);
 					btn.addEventListener('click', () => openDetail(deck, n, btn));
+					cellMap[deck.id][n] = btn;
 					grid.appendChild(btn);
 				}
 				section.appendChild(grid);
@@ -508,6 +620,7 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 				updateSummary(deck);
 			}
 			updateDashboard();
+			renderNotes();
 		}
 
 		showMasteredEl.addEventListener('change', render);


### PR DESCRIPTION
## 概要
問題集トラッカーに、連続採点を速くする機能と、メモを集約する弱点ノートを追加しました。

## 変更点
### 採点フロー高速化
- 詳細パネルに **前へ◀ ／ 次へ▶** ボタンを追加。閉じずに連続採点できる（端の問題ではボタン無効）
- **キーボード操作**: `1`=× `2`=○ `3`=◎、`←` `→` で前後の問題へ移動（メモ入力中はショートカット無効）

### 振り返りノート（弱点ノート）
- メモのある問題を1か所に集約する **「振り返りノート」** セクションを新設
- 各項目に 手応え(×/○/◎)・絞り込み(○択)・メモ本文 を表示
- 項目タップで該当問題の編集パネルを開く

### 改善
- メモ入力中はパネル再描画でテキストエリアのカーソルが飛ばないよう調整

## テスト
- `npm run build` 成功（26ページ生成）

🤖 Generated with [Claude Code](https://claude.com/claude-code)