### PR TITLE
feat: 弱点ノートに分類タグ機能を追加

### DIFF
--- a/bunko/src/pages/ans/quiz.astro
+++ b/bunko/src/pages/ans/quiz.astro
@@ -44,7 +44,7 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 		<span class="chip s-ng">× 要復習</span>
 		<span class="chip s-ok">○ できた</span>
 		<span class="chip s-mastered">◎ 理解できた</span>
-		<span class="chip s-meta">① メモ／絞り込みあり</span>
+		<span class="chip s-meta">① メモ・タグあり</span>
 	</div>
 	<p class="muted">
 		番号をタップ → パネルで <strong>×／○／◎</strong> を選び、<strong>振り返りメモ</strong>や
@@ -61,7 +61,8 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 
 	<section class="notes" id="notes-section">
 		<h2>振り返りノート（<span id="notes-count">0</span>件）</h2>
-		<p class="muted" id="notes-empty">問題にメモを書くと、ここに弱点ノートとして集約されます。各項目をタップすると編集できます。</p>
+		<p class="muted" id="notes-empty">問題にメモやタグを付けると、ここに弱点ノートとして集約されます。各項目をタップすると編集できます。</p>
+		<div class="note-tagbar" id="note-tagbar"></div>
 		<ul class="notes-list" id="notes-list"></ul>
 	</section>
 
@@ -92,6 +93,22 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 					<button type="button" data-narrowed="5">5択</button>
 					<button type="button" class="n-clear" data-narrowed="0">クリア</button>
 				</div>
+			</div>
+
+			<div class="d-section">
+				<div class="d-label">分類タグ（間違いの理由・分野）</div>
+				<div class="d-tags-preset" id="d-tags-preset">
+					<button type="button" data-tag="知識不足">知識不足</button>
+					<button type="button" data-tag="勘違い">勘違い</button>
+					<button type="button" data-tag="読み違い">読み違い</button>
+					<button type="button" data-tag="時間不足">時間不足</button>
+					<button type="button" data-tag="ケアレスミス">ケアレスミス</button>
+				</div>
+				<div class="d-tags-custom">
+					<input id="d-tag-input" type="text" placeholder="分野など任意のタグ（例: VPC, BGP）" />
+					<button type="button" id="d-tag-add">追加</button>
+				</div>
+				<div class="d-tags-active" id="d-tags-active"></div>
 			</div>
 
 			<div class="d-section">
@@ -170,6 +187,24 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 		.note-mark.m-oo { color: #2e7d32; }
 		.note-narrowed { font-size: 0.7rem; padding: 0 0.3rem; border-radius: 4px; border: 1px solid var(--sl-color-gray-5); }
 		.note-comment { white-space: pre-wrap; font-size: 0.92rem; line-height: 1.4; }
+		.note-tags { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+		.note-tags .note-tag {
+			font-size: 0.72rem; padding: 0.05rem 0.45rem; border-radius: 999px;
+			border: 1px solid var(--sl-color-gray-5); color: var(--sl-color-gray-2);
+		}
+		.note-tagbar { display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem; margin: 0.25rem 0 0.85rem; }
+		.note-tagbar .tagbar-label { font-size: 0.8rem; color: var(--sl-color-gray-3); }
+		.tagbar-chip {
+			display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.8rem; cursor: pointer;
+			padding: 0.18rem 0.6rem; border-radius: 999px; background: transparent; color: inherit;
+			border: 1px solid var(--sl-color-gray-5);
+		}
+		.tagbar-chip:hover { border-color: var(--sl-color-text-accent); }
+		.tagbar-chip b { font-variant-numeric: tabular-nums; color: var(--sl-color-gray-3); }
+		.tagbar-chip.active {
+			background: var(--sl-color-text-accent); color: var(--sl-color-black); border-color: var(--sl-color-text-accent);
+		}
+		.tagbar-chip.active b { color: var(--sl-color-black); }
 
 		.deck { margin: 0 0 2.5rem; }
 		.deck h2 { margin-bottom: 0.25rem; }
@@ -254,6 +289,36 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 			background: var(--sl-color-text-accent); color: var(--sl-color-black); border-color: var(--sl-color-text-accent);
 		}
 		.d-narrowed .n-clear { color: var(--sl-color-gray-2); }
+		.d-tags-preset { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 0.5rem; }
+		.d-tags-preset button {
+			padding: 0.25rem 0.6rem; border-radius: 999px; cursor: pointer; font-size: 0.8rem;
+			border: 1px solid var(--sl-color-gray-5); background: transparent; color: inherit;
+		}
+		.d-tags-preset button:hover { border-color: var(--sl-color-text-accent); }
+		.d-tags-preset button.active {
+			background: var(--sl-color-text-accent); color: var(--sl-color-black); border-color: var(--sl-color-text-accent);
+		}
+		.d-tags-custom { display: flex; gap: 0.4rem; }
+		.d-tags-custom input {
+			flex: 1; min-width: 0; font: inherit; padding: 0.35rem 0.55rem; border-radius: 8px;
+			border: 1px solid var(--sl-color-gray-5); background: var(--sl-color-gray-7); color: inherit;
+		}
+		.d-tags-custom button {
+			padding: 0.35rem 0.8rem; border-radius: 8px; cursor: pointer; font-size: 0.85rem; flex: none;
+			border: 1px solid var(--sl-color-gray-5); background: transparent; color: inherit;
+		}
+		.d-tags-custom button:hover { border-color: var(--sl-color-text-accent); }
+		.d-tags-active { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
+		.d-tags-active .tag-chip {
+			display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.8rem;
+			padding: 0.15rem 0.2rem 0.15rem 0.55rem; border-radius: 999px;
+			border: 1px solid var(--sl-color-gray-5);
+		}
+		.d-tags-active .tag-chip button {
+			border: none; background: transparent; color: var(--sl-color-gray-2);
+			cursor: pointer; font-size: 0.9rem; line-height: 1; padding: 0 0.25rem;
+		}
+		.d-tags-active .tag-chip button:hover { color: #c62828; }
 		#d-comment {
 			width: 100%; box-sizing: border-box; resize: vertical; font: inherit;
 			padding: 0.5rem 0.6rem; border-radius: 8px;
@@ -319,13 +384,17 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 		const deckState = (id) => (state[id] ||= {});
 		const getRec = (deckId, n) => deckState(deckId)[n];
 
-		/** 記録を保存。中身が空（マーク・絞り込み・メモすべて無し）なら削除する。 */
+		/** 記録を保存。中身が空（マーク・絞り込み・メモ・タグすべて無し）なら削除する。 */
 		function setRec(deckId, n, rec) {
 			const ds = deckState(deckId);
-			if (!rec || (!rec.mark && !rec.narrowed && !rec.comment)) delete ds[n];
+			const empty = !rec || (!rec.mark && !rec.narrowed && !rec.comment && !(rec.tags && rec.tags.length));
+			if (empty) delete ds[n];
 			else ds[n] = rec;
 			save();
 		}
+
+		// 間違いの理由などのプリセットタグ。分野タグは自由入力で追加する。
+		const PRESET_TAGS = ['知識不足', '勘違い', '読み違い', '時間不足', 'ケアレスミス'];
 
 		const root = document.getElementById('tracker');
 		const showMasteredEl = /** @type {HTMLInputElement} */ (document.getElementById('show-mastered'));
@@ -352,12 +421,14 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 			} else {
 				narrowedEl.hidden = true;
 			}
-			btn.querySelector('.c-comment').hidden = !rec?.comment;
+			const tagCount = rec?.tags?.length || 0;
+			btn.querySelector('.c-comment').hidden = !rec?.comment && tagCount === 0;
 
 			const markLabel = mark === 'oo' ? '理解できた' : mark === 'o' ? 'できた' : mark === 'x' ? '間違えた' : '未着手';
 			const extra = [
 				rec?.narrowed ? `${rec.narrowed}択まで絞れた` : '',
 				rec?.comment ? 'メモあり' : '',
+				tagCount ? `タグ${tagCount}件` : '',
 			].filter(Boolean).join('、');
 			btn.setAttribute('aria-label', `${btn.dataset.n}番: ${markLabel}${extra ? '、' + extra : ''}`);
 			btn.title = `${markLabel}${extra ? ' / ' + extra : ''}`;
@@ -427,21 +498,54 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 		const dComment = /** @type {HTMLTextAreaElement} */ (document.getElementById('d-comment'));
 		const dPrev = /** @type {HTMLButtonElement} */ (document.getElementById('d-prev'));
 		const dNext = /** @type {HTMLButtonElement} */ (document.getElementById('d-next'));
+		const dTagsPreset = document.getElementById('d-tags-preset');
+		const dTagsActive = document.getElementById('d-tags-active');
+		const dTagInput = /** @type {HTMLInputElement} */ (document.getElementById('d-tag-input'));
 		/** 編集中の対象。{deck, n, btn} */
 		let editing = null;
 
 		function refreshPanel() {
 			const rec = getRec(editing.deck.id, editing.n) || {};
+			const tags = rec.tags || [];
 			dMarks.querySelectorAll('.d-mark').forEach((b) =>
 				b.classList.toggle('active', b.dataset.mark === rec.mark)
 			);
 			dNarrowed.querySelectorAll('button').forEach((b) =>
 				b.classList.toggle('active', Number(b.dataset.narrowed) === (rec.narrowed || 0) && rec.narrowed > 0)
 			);
+			// プリセットタグの選択状態
+			dTagsPreset.querySelectorAll('button').forEach((b) =>
+				b.classList.toggle('active', tags.includes(b.dataset.tag))
+			);
+			// 自由入力で追加したタグ（プリセット以外）を削除可能チップで表示
+			dTagsActive.innerHTML = '';
+			tags.filter((t) => !PRESET_TAGS.includes(t)).forEach((t) => {
+				const chip = document.createElement('span');
+				chip.className = 'tag-chip';
+				const label = document.createElement('span');
+				label.textContent = t;
+				const rm = document.createElement('button');
+				rm.type = 'button';
+				rm.textContent = '×';
+				rm.setAttribute('aria-label', `タグ「${t}」を削除`);
+				rm.addEventListener('click', () => toggleTag(t));
+				chip.append(label, rm);
+				dTagsActive.appendChild(chip);
+			});
 			// メモ入力中はカーソルが飛ばないよう値を上書きしない
 			if (document.activeElement !== dComment) dComment.value = rec.comment || '';
 			dPrev.disabled = editing.n <= 1;
 			dNext.disabled = editing.n >= editing.deck.count;
+		}
+
+		/** タグを付け外しする（あれば削除、なければ追加）。 */
+		function toggleTag(tag) {
+			const t = tag.trim();
+			if (!t) return;
+			commitEdit((rec) => {
+				const cur = rec.tags || [];
+				rec.tags = cur.includes(t) ? cur.filter((x) => x !== t) : [...cur, t];
+			});
 		}
 
 		function commitEdit(mutate) {
@@ -485,6 +589,26 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 			commitEdit((rec) => { rec.narrowed = v && rec.narrowed !== v ? v : undefined; });
 		});
 
+		dTagsPreset.addEventListener('click', (e) => {
+			const b = e.target.closest('button');
+			if (!b || !editing) return;
+			toggleTag(b.dataset.tag);
+		});
+
+		function addCustomTag() {
+			if (!editing) return;
+			const t = dTagInput.value.trim();
+			if (!t) return;
+			const cur = getRec(editing.deck.id, editing.n)?.tags || [];
+			if (!cur.includes(t)) toggleTag(t);
+			dTagInput.value = '';
+			dTagInput.focus();
+		}
+		document.getElementById('d-tag-add').addEventListener('click', addCustomTag);
+		dTagInput.addEventListener('keydown', (e) => {
+			if (e.key === 'Enter') { e.preventDefault(); addCustomTag(); }
+		});
+
 		dComment.addEventListener('input', () => {
 			if (!editing) return;
 			commitEdit((rec) => { rec.comment = dComment.value.trim() || undefined; });
@@ -512,7 +636,7 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 		// キーボードでの採点（メモ入力中は無効）。1/2/3=×○◎、←→=前後の問題。
 		const KEY_MARK = { '1': 'x', '2': 'o', '3': 'oo' };
 		dialog.addEventListener('keydown', (e) => {
-			if (!editing || document.activeElement === dComment) return;
+			if (!editing || document.activeElement === dComment || document.activeElement === dTagInput) return;
 			if (e.key === 'ArrowLeft') { e.preventDefault(); navigate(-1); }
 			else if (e.key === 'ArrowRight') { e.preventDefault(); navigate(1); }
 			else if (KEY_MARK[e.key]) {
@@ -526,18 +650,57 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 		const notesList = document.getElementById('notes-list');
 		const notesCount = document.getElementById('notes-count');
 		const notesEmpty = document.getElementById('notes-empty');
+		const noteTagbar = document.getElementById('note-tagbar');
+		/** タグ絞り込み（null=全件表示）。 */
+		let noteTagFilter = null;
 
 		function renderNotes() {
-			const items = [];
+			// メモまたはタグのある問題を集約
+			const all = [];
 			for (const deck of DECKS) {
 				const ds = deckState(deck.id);
 				for (let n = 1; n <= deck.count; n++) {
 					const rec = ds[n];
-					if (rec && rec.comment) items.push({ deck, n, rec });
+					if (rec && (rec.comment || (rec.tags && rec.tags.length))) all.push({ deck, n, rec });
 				}
 			}
-			notesCount.textContent = String(items.length);
-			notesEmpty.hidden = items.length > 0;
+
+			// タグ別の件数集計（多い順）
+			const counts = {};
+			all.forEach(({ rec }) => (rec.tags || []).forEach((t) => { counts[t] = (counts[t] || 0) + 1; }));
+			const tagNames = Object.keys(counts).sort((a, b) => counts[b] - counts[a] || a.localeCompare(b, 'ja'));
+			if (noteTagFilter && !counts[noteTagFilter]) noteTagFilter = null;
+
+			// タグバー（クリックで絞り込み）
+			noteTagbar.innerHTML = '';
+			if (tagNames.length) {
+				const label = document.createElement('span');
+				label.className = 'tagbar-label';
+				label.textContent = 'タグで絞り込み:';
+				noteTagbar.appendChild(label);
+				for (const t of tagNames) {
+					const chip = document.createElement('button');
+					chip.type = 'button';
+					chip.className = 'tagbar-chip' + (t === noteTagFilter ? ' active' : '');
+					const name = document.createElement('span');
+					name.textContent = t;
+					const cnt = document.createElement('b');
+					cnt.textContent = String(counts[t]);
+					chip.append(name, cnt);
+					chip.addEventListener('click', () => {
+						noteTagFilter = noteTagFilter === t ? null : t;
+						renderNotes();
+					});
+					noteTagbar.appendChild(chip);
+				}
+			}
+
+			const items = noteTagFilter
+				? all.filter(({ rec }) => (rec.tags || []).includes(noteTagFilter))
+				: all;
+			notesCount.textContent = String(all.length);
+			notesEmpty.hidden = all.length > 0;
+
 			notesList.innerHTML = items
 				.map(({ deck, n, rec }) => {
 					const sym = MARK_SYMBOL[rec.mark] || '―';
@@ -546,12 +709,23 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 					return `<li><button type="button" class="note-item" data-deck="${deck.id}" data-n="${n}">
 						<span class="note-head"><span class="note-mark ${mClass}">${sym}</span>${deck.label} ${n}番${narrowed}</span>
 						<span class="note-comment"></span>
+						<span class="note-tags"></span>
 					</button></li>`;
 				})
 				.join('');
-			// コメントはユーザー入力のため textContent で安全に挿入
+			// ユーザー入力（メモ・タグ）は textContent で安全に挿入
 			notesList.querySelectorAll('.note-item').forEach((b, i) => {
-				b.querySelector('.note-comment').textContent = items[i].rec.comment;
+				const rec = items[i].rec;
+				const commentEl = b.querySelector('.note-comment');
+				commentEl.textContent = rec.comment || '';
+				commentEl.hidden = !rec.comment;
+				const tagsEl = b.querySelector('.note-tags');
+				(rec.tags || []).forEach((t) => {
+					const chip = document.createElement('span');
+					chip.className = 'note-tag';
+					chip.textContent = t;
+					tagsEl.appendChild(chip);
+				});
 			});
 		}
 


### PR DESCRIPTION
## 概要
弱点ノートを強化し、各問題に「間違いの理由・分野」タグを付けてパターンを可視化できるようにしました。

## 変更点
### 分類タグ（詳細パネル）
- 理由プリセットをトグル選択: **知識不足／勘違い／読み違い／時間不足／ケアレスミス**
- 分野など任意のタグを自由入力で追加（例: VPC, BGP）。追加タグはチップで削除可能

### 弱点ノートの集計・絞り込み
- **タグ別の件数集計バー**を追加。多い順に表示し、どこで落としているかが一目で分かる
- タグchipをクリックで**そのタグの問題だけに絞り込み**（再クリックで解除）
- 各ノートに付与タグをchip表示
- メモが無く**タグだけ**の問題もノート一覧に含めるよう拡張

### 細部
- セルのドット表示・aria-label をタグ有無に対応
- 記録の空判定にタグを加味（タグだけでも保存／全消去で削除）
- タグ入力中はキーボード採点（1/2/3・←→）を無効化
- ユーザー入力（タグ・メモ）は textContent で安全に挿入

## テスト
- `npm run build` 成功（26ページ生成）

🤖 Generated with [Claude Code](https://claude.com/claude-code)