### PR TITLE
feat: 問題集トラッカーのデザイン刷新＋動的要素のスタイル不適用バグ修正

### DIFF
--- a/bunko/src/pages/ans/quiz.astro
+++ b/bunko/src/pages/ans/quiz.astro
@@ -17,7 +17,8 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 		tableOfContents: false,
 	}}
 >
-	<p>
+	<div class="quiz">
+	<p class="lead">
 		手元の問題集の「番号」をタップすると編集パネルが開きます。問題文は扱いません。
 		記録は<strong>このブラウザ（端末）</strong>に保存され、次回も残ります。
 	</p>
@@ -124,6 +125,7 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 			</footer>
 		</div>
 	</dialog>
+	</div>
 
 	<style>
 		.legend { display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 0.5rem 0; }
@@ -337,6 +339,187 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 			border: 1px solid var(--sl-color-text-accent);
 			background: var(--sl-color-text-accent); color: var(--sl-color-black);
 		}
+
+		/* =========================================================
+		   デザイン刷新レイヤー（後勝ちで上記スタイルを上書き）
+		   配色トークン・ヒーローダッシュボード・ヒートマップ・
+		   洗練されたダイアログを定義。light/dark 両対応。
+		   ========================================================= */
+		.quiz {
+			--q-ng: #e5484d;            /* × 要復習 */
+			--q-ok: #e8930c;            /* ○ できた */
+			--q-oo: #2fa84f;            /* ◎ 理解できた */
+			--q-ng-soft: color-mix(in srgb, var(--q-ng) 15%, transparent);
+			--q-ok-soft: color-mix(in srgb, var(--q-ok) 16%, transparent);
+			--q-oo-soft: color-mix(in srgb, var(--q-oo) 15%, transparent);
+			--q-line: color-mix(in srgb, var(--sl-color-gray-4) 32%, transparent);
+			--q-surface: color-mix(in srgb, var(--sl-color-gray-5) 16%, transparent);
+			--q-r: 14px;
+			--q-r-sm: 9px;
+			--q-shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 8px 24px -10px rgba(0, 0, 0, 0.22);
+			--q-focus: 0 0 0 3px color-mix(in srgb, var(--sl-color-text-accent) 42%, transparent);
+		}
+
+		.quiz .lead {
+			font-size: 0.95rem; line-height: 1.7; color: var(--sl-color-gray-2);
+			padding-left: 0.9rem;
+			border-left: 3px solid color-mix(in srgb, var(--sl-color-text-accent) 55%, transparent);
+		}
+
+		.quiz button:focus-visible,
+		.quiz input:focus-visible,
+		.quiz textarea:focus-visible,
+		.quiz .cell:focus-visible { outline: none; box-shadow: var(--q-focus); }
+
+		/* --- ダッシュボード（ヒーロー） --- */
+		.dashboard {
+			border: 1px solid var(--q-line); border-radius: var(--q-r);
+			padding: 1.35rem 1.5rem 1.5rem; box-shadow: var(--q-shadow);
+			background:
+				radial-gradient(130% 120% at 100% 0%, color-mix(in srgb, var(--q-oo) 12%, transparent), transparent 55%),
+				radial-gradient(120% 120% at 0% 100%, color-mix(in srgb, var(--sl-color-text-accent) 8%, transparent), transparent 50%),
+				var(--sl-color-gray-7);
+		}
+		.dashboard h2 {
+			display: flex; align-items: center; gap: 0.55rem; margin: 0 0 1.1rem;
+			font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.09em;
+			color: var(--sl-color-gray-2);
+		}
+		.dashboard h2::before {
+			content: ''; width: 0.55rem; height: 0.55rem; border-radius: 50%;
+			background: var(--q-oo); box-shadow: 0 0 0 4px var(--q-oo-soft);
+		}
+		.dash-top { gap: 1.75rem; }
+		.ring {
+			width: 134px; height: 134px;
+			background: conic-gradient(var(--q-oo) calc(var(--pct) * 1%), color-mix(in srgb, var(--sl-color-gray-4) 38%, transparent) 0);
+			filter: drop-shadow(0 5px 12px var(--q-oo-soft));
+		}
+		.ring::before { inset: 13px; box-shadow: inset 0 0 0 1px var(--q-line); }
+		.ring-center b { font-size: 1.95rem; letter-spacing: -0.02em; }
+		.ring-center span { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.06em; }
+		.stats { flex: 1 1 16rem; min-width: 0; grid-template-columns: repeat(auto-fit, minmax(6rem, 1fr)); gap: 0.6rem; }
+		.stat {
+			padding: 0.6rem 0.7rem; border-radius: var(--q-r-sm);
+			background: var(--q-surface); border: 1px solid var(--q-line);
+		}
+		.stat b { font-size: 1.55rem; letter-spacing: -0.02em; }
+		.stat span { font-size: 0.74rem; }
+		.stat.s-mastered { background: var(--q-oo-soft); border-color: color-mix(in srgb, var(--q-oo) 35%, transparent); }
+		.stat.s-ok { background: var(--q-ok-soft); border-color: color-mix(in srgb, var(--q-ok) 35%, transparent); }
+		.stat.s-ng { background: var(--q-ng-soft); border-color: color-mix(in srgb, var(--q-ng) 35%, transparent); }
+		.stat.s-mastered b { color: var(--q-oo); }
+		.stat.s-ok b { color: var(--q-ok); }
+		.stat.s-ng b { color: var(--q-ng); }
+		.dash-deck-head { font-weight: 600; }
+		.bar { height: 10px; background: color-mix(in srgb, var(--sl-color-gray-4) 26%, transparent); }
+		.bar > span {
+			border-radius: 999px;
+			background: linear-gradient(90deg, color-mix(in srgb, var(--q-oo) 78%, #000) 0%, var(--q-oo) 55%, color-mix(in srgb, var(--q-oo) 55%, #8becab) 100%);
+		}
+
+		/* --- 凡例・トグル --- */
+		.legend { gap: 0.4rem 0.55rem; margin: 1.4rem 0 0.5rem; }
+		.chip { background: var(--q-surface); border-color: var(--q-line); padding: 0.2rem 0.65rem; }
+		.s-mastered::before { background: var(--q-oo); }
+		.s-ok::before { background: var(--q-ok); }
+		.s-ng::before { background: var(--q-ng); }
+		.toggle {
+			padding: 0.4rem 0.85rem; border-radius: 999px; font-size: 0.85rem;
+			border: 1px solid var(--q-line); background: var(--q-surface); transition: border-color 0.15s;
+		}
+		.toggle:hover { border-color: var(--sl-color-text-accent); }
+
+		/* --- 問題集セクション --- */
+		.deck h2 { font-size: 1.05rem; }
+		.summary { gap: 0.4rem; font-size: 0.82rem; }
+		.summary > span {
+			padding: 0.15rem 0.6rem; border-radius: 999px;
+			background: var(--q-surface); border: 1px solid var(--q-line);
+		}
+
+		/* --- グリッド（ヒートマップ） --- */
+		.grid { gap: 0.4rem; }
+		.cell {
+			border-radius: 8px; font-weight: 600;
+			background: color-mix(in srgb, var(--sl-color-gray-5) 22%, transparent);
+			color: var(--sl-color-text); border-color: var(--q-line);
+			transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.18s ease, border-color 0.15s ease;
+		}
+		.cell:hover { border-color: var(--sl-color-text-accent); transform: translateY(-2px); box-shadow: 0 5px 14px -5px rgba(0, 0, 0, 0.4); }
+		.cell:active { transform: translateY(0) scale(0.94); }
+		.cell .c-num { font-size: 0.82rem; }
+		.cell .c-narrowed { background: rgba(0, 0, 0, 0.42); color: #fff; border-radius: 4px; }
+		.cell .c-comment { box-shadow: 0 0 0 1.5px var(--sl-color-bg); }
+		.cell.mark-x { background: linear-gradient(155deg, var(--q-ng), color-mix(in srgb, var(--q-ng) 80%, #000)); color: #fff; border-color: color-mix(in srgb, var(--q-ng) 72%, #000); }
+		.cell.mark-o { background: linear-gradient(155deg, var(--q-ok), color-mix(in srgb, var(--q-ok) 82%, #000)); color: #1a1200; border-color: color-mix(in srgb, var(--q-ok) 75%, #000); }
+		.cell.mark-o .c-comment { background: #1a1200; }
+		.cell.mark-oo { background: linear-gradient(155deg, var(--q-oo), color-mix(in srgb, var(--q-oo) 80%, #000)); color: #fff; border-color: color-mix(in srgb, var(--q-oo) 72%, #000); }
+
+		.deck-actions button { border-radius: 999px; transition: border-color 0.15s, color 0.15s; }
+		.deck-actions button:hover { color: var(--q-ng); border-color: color-mix(in srgb, var(--q-ng) 55%, transparent); }
+
+		/* --- 振り返りノート --- */
+		.notes h2 { font-size: 1.05rem; }
+		.note-item {
+			border-radius: var(--q-r-sm); border-color: var(--q-line); padding: 0.7rem 0.85rem;
+			transition: border-color 0.15s, transform 0.12s, box-shadow 0.12s;
+		}
+		.note-item:hover { transform: translateY(-1px); box-shadow: var(--q-shadow); }
+		.note-mark.m-x { color: var(--q-ng); }
+		.note-mark.m-o { color: var(--q-ok); }
+		.note-mark.m-oo { color: var(--q-oo); }
+		.note-tags .note-tag {
+			background: color-mix(in srgb, var(--sl-color-text-accent) 12%, transparent);
+			border-color: color-mix(in srgb, var(--sl-color-text-accent) 30%, transparent);
+			color: var(--sl-color-text-accent);
+		}
+
+		/* --- 詳細ダイアログ --- */
+		.detail {
+			border-radius: var(--q-r); width: 23rem; border: 1px solid var(--q-line);
+			box-shadow: 0 24px 64px -16px rgba(0, 0, 0, 0.6);
+		}
+		.detail[open] { animation: q-dlg-in 0.2s cubic-bezier(0.16, 1, 0.3, 1); }
+		@keyframes q-dlg-in { from { opacity: 0; transform: translateY(10px) scale(0.97); } to { opacity: 1; transform: none; } }
+		.detail::backdrop { background: rgba(0, 0, 0, 0.55); backdrop-filter: blur(2px); }
+		.detail-card { padding: 1.1rem 1.2rem 1.2rem; }
+		.detail-head { gap: 0.4rem; margin-bottom: 1rem; }
+		.detail-head h3 { font-size: 1.1rem; font-weight: 700; }
+		.d-nav { border-radius: 8px; transition: border-color 0.15s, background 0.15s; }
+		.d-nav:hover:not(:disabled) { background: color-mix(in srgb, var(--sl-color-text-accent) 12%, transparent); }
+		.d-label { text-transform: uppercase; letter-spacing: 0.05em; font-size: 0.72rem; font-weight: 600; color: var(--sl-color-gray-3); }
+		.d-marks { gap: 0.5rem; }
+		.d-mark { padding: 0.6rem 0.2rem; border-radius: 10px; gap: 0.2rem; transition: transform 0.1s, border-color 0.15s, background 0.15s; }
+		.d-mark:active { transform: scale(0.95); }
+		.d-mark b { font-size: 1.3rem; }
+		.d-mark.active.m-ng { background: var(--q-ng); border-color: var(--q-ng); color: #fff; }
+		.d-mark.active.m-ok { background: var(--q-ok); border-color: var(--q-ok); color: #1a1200; }
+		.d-mark.active.m-mastered { background: var(--q-oo); border-color: var(--q-oo); color: #fff; }
+		.d-narrowed button, .d-tags-preset button { transition: border-color 0.15s, background 0.15s, color 0.15s; }
+		.d-tags-active .tag-chip {
+			background: color-mix(in srgb, var(--sl-color-text-accent) 10%, transparent);
+			border-color: color-mix(in srgb, var(--sl-color-text-accent) 28%, transparent);
+		}
+		#d-comment, .d-tags-custom input { transition: border-color 0.15s, box-shadow 0.15s; }
+		#d-comment:focus, .d-tags-custom input:focus { border-color: var(--sl-color-text-accent); }
+		.d-hint {
+			background: var(--q-surface); border-radius: 8px; padding: 0.45rem; margin-bottom: 0.85rem;
+		}
+		.d-hint b {
+			display: inline-block; min-width: 1.15rem; padding: 0 0.25rem; text-align: center;
+			border-radius: 4px; background: var(--sl-color-gray-6); border: 1px solid var(--sl-color-gray-5);
+		}
+		.detail-foot { margin-top: 0.5rem; }
+		.d-delete { border-radius: 8px; transition: border-color 0.15s, color 0.15s; }
+		.d-done { border-radius: 8px; font-weight: 600; padding: 0.45rem 1.2rem; transition: transform 0.1s, filter 0.15s; }
+		.d-done:hover { filter: brightness(1.08); }
+		.d-done:active { transform: scale(0.97); }
+
+		/* --- モーション軽減 --- */
+		@media (prefers-reduced-motion: reduce) {
+			.quiz *, .detail[open] { transition: none !important; animation: none !important; }
+		}
 	</style>
 
 	<script>
@@ -402,6 +585,20 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 		let cellMap = {};
 
 		const MARK_SYMBOL = { x: '×', o: '○', oo: '◎' };
+
+		// Astro はスタイルを :where(.astro-xxxx) でスコープするため、JSで動的生成した
+		// 要素にはスタイルが当たらない。テンプレート要素からスコープclassを取得し、
+		// 生成した部分木へ付与してCSSを効かせる。
+		const SCOPE = (() => {
+			const t = document.getElementById('tracker');
+			return t ? Array.from(t.classList).find((c) => c.startsWith('astro-')) : null;
+		})();
+		function scopeTree(rootEl) {
+			if (!SCOPE || !rootEl) return rootEl;
+			if (rootEl.classList) rootEl.classList.add(SCOPE);
+			rootEl.querySelectorAll && rootEl.querySelectorAll('*').forEach((n) => n.classList.add(SCOPE));
+			return rootEl;
+		}
 
 		function applyCell(btn, rec, showMastered) {
 			const mark = rec?.mark;
@@ -479,7 +676,8 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 			document.getElementById('dash-ng').textContent = String(ng);
 			document.getElementById('dash-remain').textContent = String(total - mastered - ok - ng);
 			document.getElementById('dash-total').textContent = String(total);
-			document.getElementById('dash-decks').innerHTML = perDeck
+			const dashDecks = document.getElementById('dash-decks');
+			dashDecks.innerHTML = perDeck
 				.map(({ deck, m }) => {
 					const p = Math.round((m / deck.count) * 100);
 					return `<div class="dash-deck">
@@ -488,6 +686,7 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 					</div>`;
 				})
 				.join('');
+			scopeTree(dashDecks);
 		}
 
 		// ---- 詳細パネル（ダイアログ） ----
@@ -532,6 +731,7 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 				chip.append(label, rm);
 				dTagsActive.appendChild(chip);
 			});
+			scopeTree(dTagsActive);
 			// メモ入力中はカーソルが飛ばないよう値を上書きしない
 			if (document.activeElement !== dComment) dComment.value = rec.comment || '';
 			dPrev.disabled = editing.n <= 1;
@@ -727,6 +927,8 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 					tagsEl.appendChild(chip);
 				});
 			});
+			scopeTree(notesList);
+			scopeTree(noteTagbar);
 		}
 
 		notesList.addEventListener('click', (e) => {
@@ -791,6 +993,7 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 				section.appendChild(actions);
 
 				root.appendChild(section);
+				scopeTree(section);
 				updateSummary(deck);
 			}
 			updateDashboard();


### PR DESCRIPTION
## 概要
問題集トラッカーのデザインを本格的に磨き込みました。あわせて、JSで動的生成する要素にスタイルが当たっていなかった既存バグを修正しています。

## デザイン刷新
- **配色トークン化**: ×/○/◎ の色を一元管理し、light/dark 両テーマに対応
- **ヒーローダッシュボード**: グラデ背景・到達度リング・ソフトトーンの統計カード・グラデ進捗バー
- **ヒートマップ調のセル**: 適応的な地色＋マークのグラデーション、ホバーで浮き上がり・押下で凹む操作感
- **洗練されたダイアログ**: セグメント風の手応え選択、キーキャップ表示のヒント、入場アニメ＋背景ブラー、プライマリボタン
- **チップ／タグ**: アクセント配色で統一感
- `prefers-reduced-motion` でモーション軽減に配慮

## 不具合修正（既存バグ）
- Astro は `<style>` を `:where(.astro-xxxx)` でスコープするため、**JSで動的生成していたセル・進捗バー・振り返りノート・タグchip にコンポーネントのスタイルが一切当たっていなかった**（ヒートマップの色やバーが表示されない状態）。テンプレート要素からスコープclassを取得して生成部分木へ付与する `scopeTree()` を追加して修正。
- 統計カードが flex 子要素の縮小で `auto-fit` が1列に潰れる問題を `flex: 1` で修正。

## 検証
- `npm run build` 成功（26ページ）
- Playwright で dark/light 両テーマのスクリーンショットを取得し、ヒートマップ・ダッシュボード・ダイアログ・ノートの表示と計算済みスタイル（グラデ適用・4列グリッド）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)